### PR TITLE
feat: use service comment as MCP server name

### DIFF
--- a/cmd/protoc-gen-connect-go-mcp/template/template.go
+++ b/cmd/protoc-gen-connect-go-mcp/template/template.go
@@ -42,10 +42,16 @@ func generateImports(g *protogen.GeneratedFile, services []parser.Service) {
 
 // generateServerWithTools generates MCP server initialization function
 func generateServerWithTools(g *protogen.GeneratedFile, service parser.Service) {
+	// Use service comment as MCP server name if available, otherwise use service name
+	serverName := service.Comment
+	if serverName == "" {
+		serverName = service.Name
+	}
+
 	g.P("// NewMCPServerWithTools creates and returns a configured ", service.Name, " MCP server")
 	g.P("func New", service.Name, "MCPServer(baseURL string, opts ...connectgomcp.ClientOption) *mcp.Server {")
 	g.P("  server := mcp.NewServer(&mcp.Implementation{")
-	g.P("    Name: \"", service.Name, "\",")
+	g.P("    Name: \"", escapeString(serverName), "\",")
 	g.P("    Version: \"1.0.0\",")
 	g.P("  }, nil)")
 	g.P()

--- a/cmd/protoc-gen-connect-go-mcp/testdata/greet/gen/greetv1mcp/greet.mcpserver.go
+++ b/cmd/protoc-gen-connect-go-mcp/testdata/greet/gen/greetv1mcp/greet.mcpserver.go
@@ -11,7 +11,7 @@ import (
 // NewMCPServerWithTools creates and returns a configured GreetService MCP server
 func NewGreetServiceMCPServer(baseURL string, opts ...connectgomcp.ClientOption) *mcp.Server {
 	server := mcp.NewServer(&mcp.Implementation{
-		Name:    "GreetService",
+		Name:    "Greeting service",
 		Version: "1.0.0",
 	}, nil)
 

--- a/cmd/protoc-gen-connect-go-mcp/testdata/multiline-comments/gen/testv1mcp/test.mcpserver.go
+++ b/cmd/protoc-gen-connect-go-mcp/testdata/multiline-comments/gen/testv1mcp/test.mcpserver.go
@@ -11,7 +11,7 @@ import (
 // NewMCPServerWithTools creates and returns a configured TestService MCP server
 func NewTestServiceMCPServer(baseURL string, opts ...connectgomcp.ClientOption) *mcp.Server {
 	server := mcp.NewServer(&mcp.Implementation{
-		Name:    "TestService",
+		Name:    "TestService provides test functionality\nThis service demonstrates handling of multiline comments in proto files",
 		Version: "1.0.0",
 	}, nil)
 

--- a/cmd/protoc-gen-connect-go-mcp/testdata/package-suffix/gen/greet.mcpserver.go
+++ b/cmd/protoc-gen-connect-go-mcp/testdata/package-suffix/gen/greet.mcpserver.go
@@ -11,7 +11,7 @@ import (
 // NewMCPServerWithTools creates and returns a configured GreetService MCP server
 func NewGreetServiceMCPServer(baseURL string, opts ...connectgomcp.ClientOption) *mcp.Server {
 	server := mcp.NewServer(&mcp.Implementation{
-		Name:    "GreetService",
+		Name:    "Greeting service",
 		Version: "1.0.0",
 	}, nil)
 


### PR DESCRIPTION
When a proto service has a leading comment, use it as the MCP server name instead of the service name. This allows more descriptive server names in MCP clients like Claude Desktop.

If no comment is present, falls back to the service name.