### PR TITLE
fix: prevent httpClient nil overwrite when using WithHTTPHeaders

### DIFF
--- a/option.go
+++ b/option.go
@@ -14,7 +14,9 @@ type httpClientOption struct {
 }
 
 func (o *httpClientOption) apply(c *toolConfig) {
-	c.httpClient = o.client
+	if o.client != nil {
+		c.httpClient = o.client
+	}
 
 	if o.headers != nil {
 		c.httpHeaders = http.Header{}

--- a/option_test.go
+++ b/option_test.go
@@ -1,0 +1,98 @@
+package connectgomcp
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestWithHTTPHeaders_DoesNotOverwriteHTTPClient(t *testing.T) {
+	// When only WithHTTPHeaders is used, http.DefaultClient should be preserved
+	handler := NewToolHandler("http://localhost:8080", WithHTTPHeaders(map[string]string{
+		"Authorization": "Bearer token",
+	}))
+
+	if handler.config.httpClient == nil {
+		t.Error("httpClient should not be nil when only WithHTTPHeaders is used")
+	}
+
+	if handler.config.httpClient != http.DefaultClient {
+		t.Error("httpClient should be http.DefaultClient when only WithHTTPHeaders is used")
+	}
+
+	if handler.config.httpHeaders.Get("Authorization") != "Bearer token" {
+		t.Errorf("expected Authorization header to be 'Bearer token', got '%s'", handler.config.httpHeaders.Get("Authorization"))
+	}
+}
+
+func TestWithHTTPClient_SetsHTTPClient(t *testing.T) {
+	// When WithHTTPClient is used, the specified client should be used
+	customClient := &http.Client{}
+	handler := NewToolHandler("http://localhost:8080", WithHTTPClient(customClient))
+
+	if handler.config.httpClient == nil {
+		t.Error("httpClient should not be nil")
+	}
+
+	if handler.config.httpClient != customClient {
+		t.Error("httpClient should be the custom client")
+	}
+}
+
+func TestWithHTTPClientAndHeaders_BothAreSet(t *testing.T) {
+	// When both options are used, both settings should be applied
+	customClient := &http.Client{}
+	handler := NewToolHandler("http://localhost:8080",
+		WithHTTPClient(customClient),
+		WithHTTPHeaders(map[string]string{
+			"Authorization": "Bearer token",
+		}),
+	)
+
+	if handler.config.httpClient == nil {
+		t.Error("httpClient should not be nil")
+	}
+
+	if handler.config.httpClient != customClient {
+		t.Error("httpClient should be the custom client")
+	}
+
+	if handler.config.httpHeaders.Get("Authorization") != "Bearer token" {
+		t.Errorf("expected Authorization header to be 'Bearer token', got '%s'", handler.config.httpHeaders.Get("Authorization"))
+	}
+}
+
+func TestWithHTTPHeadersThenClient_BothAreSet(t *testing.T) {
+	// Order should not matter - test headers first, then client
+	customClient := &http.Client{}
+	handler := NewToolHandler("http://localhost:8080",
+		WithHTTPHeaders(map[string]string{
+			"X-Custom-Header": "value",
+		}),
+		WithHTTPClient(customClient),
+	)
+
+	if handler.config.httpClient == nil {
+		t.Error("httpClient should not be nil")
+	}
+
+	if handler.config.httpClient != customClient {
+		t.Error("httpClient should be the custom client")
+	}
+
+	if handler.config.httpHeaders.Get("X-Custom-Header") != "value" {
+		t.Errorf("expected X-Custom-Header to be 'value', got '%s'", handler.config.httpHeaders.Get("X-Custom-Header"))
+	}
+}
+
+func TestDefaultToolHandler_UsesDefaultClient(t *testing.T) {
+	// With no options, http.DefaultClient should be used
+	handler := NewToolHandler("http://localhost:8080")
+
+	if handler.config.httpClient == nil {
+		t.Error("httpClient should not be nil")
+	}
+
+	if handler.config.httpClient != http.DefaultClient {
+		t.Error("httpClient should be http.DefaultClient by default")
+	}
+}


### PR DESCRIPTION
WithHTTPHeaders option was overwriting httpClient with nil, causing panic. Now apply() only sets httpClient when o.client is not nil.