### PR TITLE
fix: MCP命名規則に準拠するようツール名・サービス名を修正

### DIFF
--- a/cmd/protoc-gen-connect-go-mcp/main_test.go
+++ b/cmd/protoc-gen-connect-go-mcp/main_test.go
@@ -92,10 +92,12 @@ func TestGenerate(t *testing.T) {
 	assert.Contains(t, content, `package greetv1`)
 	assert.Contains(t, content, `func NewGreetServiceMCPServer`)
 	assert.Contains(t, content, `mcp.AddTool(`)
-	assert.Contains(t, content, `Name:        "Greet RPC",`)
-	assert.Contains(t, content, `Description: "Greeting request\nThis is a test for multi-line comments\nParameter name: The name of the person to greet",`)
-	assert.Contains(t, content, `Name:        "Ping RPC",`)
-	assert.Contains(t, content, `Description: "Ping request",`)
+	// Tool names should be method names (MCP naming convention compliance)
+	assert.Contains(t, content, `Name:        "Greet",`)
+	assert.Contains(t, content, `Name:        "Ping",`)
+	// Descriptions should include both RPC comment and request comment
+	assert.Contains(t, content, `Description: "Greet RPC\n\nGreeting request`)
+	assert.Contains(t, content, `Description: "Ping RPC\n\nPing request",`)
 	// Parameters are handled differently in the new SDK
 }
 

--- a/cmd/protoc-gen-connect-go-mcp/template/template.go
+++ b/cmd/protoc-gen-connect-go-mcp/template/template.go
@@ -43,11 +43,8 @@ func generateImports(g *protogen.GeneratedFile, services []parser.Service) {
 
 // generateServerWithTools generates MCP server initialization function
 func generateServerWithTools(g *protogen.GeneratedFile, service parser.Service) {
-	// Use service comment as MCP server name if available, otherwise use service name
-	serverName := service.Comment
-	if serverName == "" {
-		serverName = service.Name
-	}
+	// サービス名は常にprotoサービス名を使用（MCP命名規則 ^[a-zA-Z0-9_-]{1,64}$ に準拠）
+	serverName := service.Name
 
 	g.P("// NewMCPServerWithTools creates and returns a configured ", service.Name, " MCP server")
 	g.P("func New", service.Name, "MCPServer(baseURL string, opts ...connectgomcp.ClientOption) *mcp.Server {")

--- a/cmd/protoc-gen-connect-go-mcp/template/template.go
+++ b/cmd/protoc-gen-connect-go-mcp/template/template.go
@@ -60,12 +60,14 @@ func generateServerWithTools(g *protogen.GeneratedFile, service parser.Service) 
 
 	// Tool registration for each method
 	for i, method := range service.Methods {
-		toolName := method.Comment
-		if toolName == "" {
-			toolName = method.Name
-		}
+		// ツール名は常にRPCメソッド名を使用（MCP命名規則 ^[a-zA-Z0-9_-]{1,64}$ に準拠）
+		toolName := method.Name
 
-		description := method.RequestComment
+		// 説明はコメントを優先
+		description := method.Comment
+		if description == "" {
+			description = method.RequestComment
+		}
 		if description == "" {
 			description = "Call " + method.Name + " method"
 		}

--- a/cmd/protoc-gen-connect-go-mcp/template/template.go
+++ b/cmd/protoc-gen-connect-go-mcp/template/template.go
@@ -60,11 +60,15 @@ func generateServerWithTools(g *protogen.GeneratedFile, service parser.Service) 
 		// ツール名は常にRPCメソッド名を使用（MCP命名規則 ^[a-zA-Z0-9_-]{1,64}$ に準拠）
 		toolName := method.Name
 
-		// 説明はコメントを優先
-		description := method.Comment
-		if description == "" {
-			description = method.RequestComment
+		// 説明はRPCコメントとリクエストコメントを両方含める
+		var descriptionParts []string
+		if method.Comment != "" {
+			descriptionParts = append(descriptionParts, method.Comment)
 		}
+		if method.RequestComment != "" {
+			descriptionParts = append(descriptionParts, method.RequestComment)
+		}
+		description := strings.Join(descriptionParts, "\n\n")
 		if description == "" {
 			description = "Call " + method.Name + " method"
 		}

--- a/cmd/protoc-gen-connect-go-mcp/testdata/greet/gen/greetv1mcp/greet.mcpserver.go
+++ b/cmd/protoc-gen-connect-go-mcp/testdata/greet/gen/greetv1mcp/greet.mcpserver.go
@@ -12,7 +12,7 @@ import (
 // NewMCPServerWithTools creates and returns a configured GreetService MCP server
 func NewGreetServiceMCPServer(baseURL string, opts ...connectgomcp.ClientOption) *mcp.Server {
 	server := mcp.NewServer(&mcp.Implementation{
-		Name:    "Greeting service",
+		Name:    "GreetService",
 		Version: "1.0.0",
 	}, nil)
 

--- a/cmd/protoc-gen-connect-go-mcp/testdata/greet/gen/greetv1mcp/greet.mcpserver.go
+++ b/cmd/protoc-gen-connect-go-mcp/testdata/greet/gen/greetv1mcp/greet.mcpserver.go
@@ -21,7 +21,7 @@ func NewGreetServiceMCPServer(baseURL string, opts ...connectgomcp.ClientOption)
 		server,
 		&mcp.Tool{
 			Name:        "Greet",
-			Description: "Greet RPC",
+			Description: "Greet RPC\n\nGreeting request\nThis is a test for multi-line comments\nParameter name: The name of the person to greet",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -45,7 +45,7 @@ func NewGreetServiceMCPServer(baseURL string, opts ...connectgomcp.ClientOption)
 		server,
 		&mcp.Tool{
 			Name:        "Ping",
-			Description: "Ping RPC",
+			Description: "Ping RPC\n\nPing request",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{

--- a/cmd/protoc-gen-connect-go-mcp/testdata/greet/gen/greetv1mcp/greet.mcpserver.go
+++ b/cmd/protoc-gen-connect-go-mcp/testdata/greet/gen/greetv1mcp/greet.mcpserver.go
@@ -20,8 +20,8 @@ func NewGreetServiceMCPServer(baseURL string, opts ...connectgomcp.ClientOption)
 	mcp.AddTool(
 		server,
 		&mcp.Tool{
-			Name:        "Greet RPC",
-			Description: "Greeting request\nThis is a test for multi-line comments\nParameter name: The name of the person to greet",
+			Name:        "Greet",
+			Description: "Greet RPC",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -44,8 +44,8 @@ func NewGreetServiceMCPServer(baseURL string, opts ...connectgomcp.ClientOption)
 	mcp.AddTool(
 		server,
 		&mcp.Tool{
-			Name:        "Ping RPC",
-			Description: "Ping request",
+			Name:        "Ping",
+			Description: "Ping RPC",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{

--- a/cmd/protoc-gen-connect-go-mcp/testdata/multiline-comments/gen/testv1mcp/test.mcpserver.go
+++ b/cmd/protoc-gen-connect-go-mcp/testdata/multiline-comments/gen/testv1mcp/test.mcpserver.go
@@ -21,7 +21,7 @@ func NewTestServiceMCPServer(baseURL string, opts ...connectgomcp.ClientOption) 
 		server,
 		&mcp.Tool{
 			Name:        "CreateUser",
-			Description: "CreateUser - Creates a new user account in the system.\nNOTE: This method requires valid email verification before account activation.",
+			Description: "CreateUser - Creates a new user account in the system.\nNOTE: This method requires valid email verification before account activation.\n\nCreateUser - Creates a new user account.\n\nPrerequisites:\n- Valid email address\n- User must not already exist\n- Terms of service must be accepted",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -53,7 +53,7 @@ func NewTestServiceMCPServer(baseURL string, opts ...connectgomcp.ClientOption) 
 		server,
 		&mcp.Tool{
 			Name:        "GetUser",
-			Description: "GetUser - Retrieves user information by user ID.\n\nPrerequisites:\n- Valid user ID must be provided\n- User must exist in the system",
+			Description: "GetUser - Retrieves user information by user ID.\n\nPrerequisites:\n- Valid user ID must be provided\n- User must exist in the system\n\nGetUser - Retrieves user information.\n\nReturns:\n- User profile data if found\n- Error if user does not exist",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -77,7 +77,7 @@ func NewTestServiceMCPServer(baseURL string, opts ...connectgomcp.ClientOption) 
 		server,
 		&mcp.Tool{
 			Name:        "UpdateUser",
-			Description: "UpdateUser - Updates an existing user's information.\n\nThis operation allows updating user profile data.\nOnly the fields provided in the request will be updated.",
+			Description: "UpdateUser - Updates an existing user's information.\n\nThis operation allows updating user profile data.\nOnly the fields provided in the request will be updated.\n\nUpdateUser - Updates user information.\n\nOnly non-empty fields will be updated.\nTo clear a field, use the appropriate \"clear_*\" flag.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -109,7 +109,7 @@ func NewTestServiceMCPServer(baseURL string, opts ...connectgomcp.ClientOption) 
 		server,
 		&mcp.Tool{
 			Name:        "DeleteUser",
-			Description: "DeleteUser - Deletes a user account from the system.\n\nWARNING: This operation is irreversible!\nAll user data will be permanently deleted.",
+			Description: "DeleteUser - Deletes a user account from the system.\n\nWARNING: This operation is irreversible!\nAll user data will be permanently deleted.\n\nDeleteUser - Permanently deletes a user.\n\nWARNING: This cannot be undone!",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -137,7 +137,7 @@ func NewTestServiceMCPServer(baseURL string, opts ...connectgomcp.ClientOption) 
 		server,
 		&mcp.Tool{
 			Name:        "SyncData",
-			Description: "SyncData\nSynchronizes data between the client and server.\nThis operation may take several minutes depending on the data size.",
+			Description: "SyncData\nSynchronizes data between the client and server.\nThis operation may take several minutes depending on the data size.\n\nSyncDataRequest\nRequest message for synchronizing data.\nThe sync operation will process all pending changes since the last sync.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -165,7 +165,7 @@ func NewTestServiceMCPServer(baseURL string, opts ...connectgomcp.ClientOption) 
 		server,
 		&mcp.Tool{
 			Name:        "ProcessPayment",
-			Description: "ProcessPayment - Processes a payment transaction.\n\nThis is a test RPC for demonstrating multiline comments.\nIt includes special characters like \"quotes\" and \\backslashes\\.\nMultiple lines should be properly escaped in the generated code.",
+			Description: "ProcessPayment - Processes a payment transaction.\n\nThis is a test RPC for demonstrating multiline comments.\nIt includes special characters like \"quotes\" and \\backslashes\\.\nMultiple lines should be properly escaped in the generated code.\n\nProcessPaymentRequest\nRequest for processing a payment.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{

--- a/cmd/protoc-gen-connect-go-mcp/testdata/multiline-comments/gen/testv1mcp/test.mcpserver.go
+++ b/cmd/protoc-gen-connect-go-mcp/testdata/multiline-comments/gen/testv1mcp/test.mcpserver.go
@@ -20,8 +20,8 @@ func NewTestServiceMCPServer(baseURL string, opts ...connectgomcp.ClientOption) 
 	mcp.AddTool(
 		server,
 		&mcp.Tool{
-			Name:        "CreateUser - Creates a new user account in the system.\nNOTE: This method requires valid email verification before account activation.",
-			Description: "CreateUser - Creates a new user account.\n\nPrerequisites:\n- Valid email address\n- User must not already exist\n- Terms of service must be accepted",
+			Name:        "CreateUser",
+			Description: "CreateUser - Creates a new user account in the system.\nNOTE: This method requires valid email verification before account activation.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -52,8 +52,8 @@ func NewTestServiceMCPServer(baseURL string, opts ...connectgomcp.ClientOption) 
 	mcp.AddTool(
 		server,
 		&mcp.Tool{
-			Name:        "GetUser - Retrieves user information by user ID.\n\nPrerequisites:\n- Valid user ID must be provided\n- User must exist in the system",
-			Description: "GetUser - Retrieves user information.\n\nReturns:\n- User profile data if found\n- Error if user does not exist",
+			Name:        "GetUser",
+			Description: "GetUser - Retrieves user information by user ID.\n\nPrerequisites:\n- Valid user ID must be provided\n- User must exist in the system",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -76,8 +76,8 @@ func NewTestServiceMCPServer(baseURL string, opts ...connectgomcp.ClientOption) 
 	mcp.AddTool(
 		server,
 		&mcp.Tool{
-			Name:        "UpdateUser - Updates an existing user's information.\n\nThis operation allows updating user profile data.\nOnly the fields provided in the request will be updated.",
-			Description: "UpdateUser - Updates user information.\n\nOnly non-empty fields will be updated.\nTo clear a field, use the appropriate \"clear_*\" flag.",
+			Name:        "UpdateUser",
+			Description: "UpdateUser - Updates an existing user's information.\n\nThis operation allows updating user profile data.\nOnly the fields provided in the request will be updated.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -108,8 +108,8 @@ func NewTestServiceMCPServer(baseURL string, opts ...connectgomcp.ClientOption) 
 	mcp.AddTool(
 		server,
 		&mcp.Tool{
-			Name:        "DeleteUser - Deletes a user account from the system.\n\nWARNING: This operation is irreversible!\nAll user data will be permanently deleted.",
-			Description: "DeleteUser - Permanently deletes a user.\n\nWARNING: This cannot be undone!",
+			Name:        "DeleteUser",
+			Description: "DeleteUser - Deletes a user account from the system.\n\nWARNING: This operation is irreversible!\nAll user data will be permanently deleted.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -136,8 +136,8 @@ func NewTestServiceMCPServer(baseURL string, opts ...connectgomcp.ClientOption) 
 	mcp.AddTool(
 		server,
 		&mcp.Tool{
-			Name:        "SyncData\nSynchronizes data between the client and server.\nThis operation may take several minutes depending on the data size.",
-			Description: "SyncDataRequest\nRequest message for synchronizing data.\nThe sync operation will process all pending changes since the last sync.",
+			Name:        "SyncData",
+			Description: "SyncData\nSynchronizes data between the client and server.\nThis operation may take several minutes depending on the data size.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -164,8 +164,8 @@ func NewTestServiceMCPServer(baseURL string, opts ...connectgomcp.ClientOption) 
 	mcp.AddTool(
 		server,
 		&mcp.Tool{
-			Name:        "ProcessPayment - Processes a payment transaction.\n\nThis is a test RPC for demonstrating multiline comments.\nIt includes special characters like \"quotes\" and \\backslashes\\.\nMultiple lines should be properly escaped in the generated code.",
-			Description: "ProcessPaymentRequest\nRequest for processing a payment.",
+			Name:        "ProcessPayment",
+			Description: "ProcessPayment - Processes a payment transaction.\n\nThis is a test RPC for demonstrating multiline comments.\nIt includes special characters like \"quotes\" and \\backslashes\\.\nMultiple lines should be properly escaped in the generated code.",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{

--- a/cmd/protoc-gen-connect-go-mcp/testdata/multiline-comments/gen/testv1mcp/test.mcpserver.go
+++ b/cmd/protoc-gen-connect-go-mcp/testdata/multiline-comments/gen/testv1mcp/test.mcpserver.go
@@ -12,7 +12,7 @@ import (
 // NewMCPServerWithTools creates and returns a configured TestService MCP server
 func NewTestServiceMCPServer(baseURL string, opts ...connectgomcp.ClientOption) *mcp.Server {
 	server := mcp.NewServer(&mcp.Implementation{
-		Name:    "TestService provides test functionality\nThis service demonstrates handling of multiline comments in proto files",
+		Name:    "TestService",
 		Version: "1.0.0",
 	}, nil)
 

--- a/cmd/protoc-gen-connect-go-mcp/testdata/package-suffix/gen/greet.mcpserver.go
+++ b/cmd/protoc-gen-connect-go-mcp/testdata/package-suffix/gen/greet.mcpserver.go
@@ -21,7 +21,7 @@ func NewGreetServiceMCPServer(baseURL string, opts ...connectgomcp.ClientOption)
 		server,
 		&mcp.Tool{
 			Name:        "Greet",
-			Description: "Greet RPC",
+			Description: "Greet RPC\n\nGreeting request",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -45,7 +45,7 @@ func NewGreetServiceMCPServer(baseURL string, opts ...connectgomcp.ClientOption)
 		server,
 		&mcp.Tool{
 			Name:        "Ping",
-			Description: "Ping RPC",
+			Description: "Ping RPC\n\nPing request",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{

--- a/cmd/protoc-gen-connect-go-mcp/testdata/package-suffix/gen/greet.mcpserver.go
+++ b/cmd/protoc-gen-connect-go-mcp/testdata/package-suffix/gen/greet.mcpserver.go
@@ -12,7 +12,7 @@ import (
 // NewMCPServerWithTools creates and returns a configured GreetService MCP server
 func NewGreetServiceMCPServer(baseURL string, opts ...connectgomcp.ClientOption) *mcp.Server {
 	server := mcp.NewServer(&mcp.Implementation{
-		Name:    "Greeting service",
+		Name:    "GreetService",
 		Version: "1.0.0",
 	}, nil)
 

--- a/cmd/protoc-gen-connect-go-mcp/testdata/package-suffix/gen/greet.mcpserver.go
+++ b/cmd/protoc-gen-connect-go-mcp/testdata/package-suffix/gen/greet.mcpserver.go
@@ -20,8 +20,8 @@ func NewGreetServiceMCPServer(baseURL string, opts ...connectgomcp.ClientOption)
 	mcp.AddTool(
 		server,
 		&mcp.Tool{
-			Name:        "Greet RPC",
-			Description: "Greeting request",
+			Name:        "Greet",
+			Description: "Greet RPC",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{
@@ -44,8 +44,8 @@ func NewGreetServiceMCPServer(baseURL string, opts ...connectgomcp.ClientOption)
 	mcp.AddTool(
 		server,
 		&mcp.Tool{
-			Name:        "Ping RPC",
-			Description: "Ping request",
+			Name:        "Ping",
+			Description: "Ping RPC",
 			InputSchema: &jsonschema.Schema{
 				Type: "object",
 				Properties: map[string]*jsonschema.Schema{

--- a/scripts/deploy_local.sh
+++ b/scripts/deploy_local.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 go build ./cmd/protoc-gen-connect-go-mcp
-mv ./protoc-gen-connect-go-mcp ~/.local/bin/protoc-gen-connect-go-mcp
+mv ./protoc-gen-connect-go-mcp ~/go/bin/protoc-gen-connect-go-mcp


### PR DESCRIPTION
  ## 概要                                                                       
  MCPのツール名およびサービス名が命名規則 `^[a-zA-Z0-9_-]{1,64}$`               
  に違反していたため、protoのメソッド名・サービス名を直接使用するように修正。   
                                                                                
  ### 変更内容                                                                  
  - MCPツール名をprotoのRPCメソッド名から直接取得するように変更（以前はコメント 
  を使用）                                                                      
  - MCPサーバー名をprotoのサービス名から直接取得するように変更（以前はコメントを
  使用）                                                                        
  - RPCメソッドのコメントはツールのDescriptionフィールドに移動                  
                                                                                
  ### 期待すること                                                              
  - MCPクライアント（Claude                                                     
  Desktop等）でツール登録時のバリデーションエラーが解消される                   
  - 生成されるツール名・サービス名がMCP仕様に準拠する                           
                                                                                
  ### 動作確認                                                                  
                                                                                
  項目 | 証憑(スクショなど) | 備考                                              
  -- | -- | --                                                                  
  生成コードのツール名が英数字のみになること | - | `"Greet RPC"` → `"Greet"`    
  生成コードのサービス名が英数字のみになること | - | `"Greeting service"` →     
  `"GreetService"`                                                              
  MCPクライアントでツール登録エラーが発生しないこと | - | 実機確認推奨 