### PR TITLE
fix: preserve Connect RPC error message on non-200 responses

### DIFF
--- a/tool_handler.go
+++ b/tool_handler.go
@@ -63,6 +63,17 @@ func (h *ToolHandler) httpRequest(ctx context.Context, req *mcp.CallToolRequest,
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		var wireErr struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		}
+		if err := json.Unmarshal(body, &wireErr); err == nil && wireErr.Message != "" {
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{Text: wireErr.Message}},
+				IsError: true,
+			}, nil
+		}
 		return nil, fmt.Errorf("status code: %d", resp.StatusCode)
 	}
 

--- a/tool_handler_test.go
+++ b/tool_handler_test.go
@@ -1,0 +1,96 @@
+package connectgomcp
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestHttpRequest_NonOK_WithConnectError(t *testing.T) {
+	wireErr := struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	}{
+		Code:    "not_found",
+		Message: "the requested resource was not found",
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(wireErr)
+	}))
+	defer server.Close()
+
+	handler := NewToolHandler(server.URL)
+	result, err := handler.Handle(context.Background(), &mcp.CallToolRequest{}, "test.Service/Method", map[string]any{})
+
+	if err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if !result.IsError {
+		t.Error("expected IsError to be true")
+	}
+	if len(result.Content) != 1 {
+		t.Fatalf("expected 1 content item, got %d", len(result.Content))
+	}
+	tc, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatal("expected TextContent")
+	}
+	if tc.Text != wireErr.Message {
+		t.Errorf("expected message %q, got %q", wireErr.Message, tc.Text)
+	}
+}
+
+func TestHttpRequest_NonOK_WithoutConnectError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("internal server error"))
+	}))
+	defer server.Close()
+
+	handler := NewToolHandler(server.URL)
+	result, err := handler.Handle(context.Background(), &mcp.CallToolRequest{}, "test.Service/Method", map[string]any{})
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if result != nil {
+		t.Error("expected nil result")
+	}
+}
+
+func TestHttpRequest_NonOK_EmptyMessage(t *testing.T) {
+	wireErr := struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	}{
+		Code:    "internal",
+		Message: "",
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(wireErr)
+	}))
+	defer server.Close()
+
+	handler := NewToolHandler(server.URL)
+	result, err := handler.Handle(context.Background(), &mcp.CallToolRequest{}, "test.Service/Method", map[string]any{})
+
+	if err == nil {
+		t.Fatal("expected error for empty message, got nil")
+	}
+	if result != nil {
+		t.Error("expected nil result")
+	}
+}


### PR DESCRIPTION
## Summary
- 非200レスポンス時にConnect RPCのエラーレスポンスボディをパースし、`message`フィールドを`CallToolResult{IsError: true}`で返すように修正
- パースできない場合や`message`が空の場合は従来通り`fmt.Errorf`でステータスコードを返却
- `tool_handler_test.go`を新規追加し、3つのテストケースでエラーハンドリングを検証

## Test plan
- [x] Connect RPCエラー（JSON body with message）→ `CallToolResult{IsError: true}` が返ること
- [x] 非JSONレスポンス → 従来通り `error` が返ること
- [x] messageが空のJSONレスポンス → 従来通り `error` が返ること
- [x] `go test ./...` 全テストPASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)